### PR TITLE
Fix repost folder routing and Windows folder opening

### DIFF
--- a/app.go
+++ b/app.go
@@ -350,9 +350,9 @@ func (a *App) DownloadMediaWithMetadata(req DownloadMediaWithMetadataRequest) (D
 		}
 
 		username := req.Username
-		if item.AuthorUsername != "" {
-			username = item.AuthorUsername
-		}
+if (req.Username == "bookmarks" || req.Username == "likes") && item.AuthorUsername != "" {
+    username = item.AuthorUsername
+}
 
 		items[i] = backend.MediaItem{
 			URL:              item.URL,

--- a/backend/folder.go
+++ b/backend/folder.go
@@ -11,6 +11,7 @@ import (
 )
 
 func OpenFolderInExplorer(path string) error {
+    os.WriteFile(filepath.Join(os.TempDir(), "openfolder.txt"), []byte(path), 0644)
 	info, err := os.Stat(path)
 	if err != nil {
 		return err
@@ -23,7 +24,7 @@ func OpenFolderInExplorer(path string) error {
 
 	switch runtime.GOOS {
 	case "windows":
-		cmd = exec.Command("explorer", path)
+		cmd = exec.Command("cmd", "/C", "start", "", path)
 	case "darwin":
 		cmd = exec.Command("open", path)
 	case "linux":


### PR DESCRIPTION
This PR fixes two Windows issues I encountered while using v4.7.

1. Repost downloads

When "Include Reposts" is enabled, reposted media is currently saved into folders named after the original author. This can create thousands of unexpected folders and separates reposted media from the account being downloaded.

This change keeps reposts inside the downloaded account's folder, while preserving the existing behavior for Bookmarks and Likes, where grouping by the original author is still useful.

2. Open Folder

On my Windows system, "Open Folder" consistently failed with "Failed to open folder", even though the folder existed.

Replacing the direct explorer invocation with:

cmd = exec.Command("cmd", "/C", "start", "", path)

resolved the issue reliably.

Both changes have been tested successfully on Windows 11 25H2