### PR TITLE
Fix 'Edit Group' dialog and 'Skip Existing Posts' behavior

### DIFF
--- a/backend/download.go
+++ b/backend/download.go
@@ -340,13 +340,34 @@ func DownloadMediaWithMetadataProgressAndStatus(items []MediaItem, outputDir str
 	}
 
 	filenameIndexes := make(map[string]int, len(filenameCounts))
-	tasks := make([]downloadTask, 0, len(pendingTasks))
-	for _, pending := range pendingTasks {
-		key := filenameCollisionKey(pending.typeDir, pending.baseName, pending.ext)
-		filenameIndexes[key]++
-		pending.task.outputPath = filepath.Join(pending.typeDir, formatDownloadFilename(pending.baseName, pending.ext, filenameCounts[key], filenameIndexes[key]))
-		tasks = append(tasks, pending.task)
+tasks := make([]downloadTask, 0, len(pendingTasks))
+
+for _, pending := range pendingTasks {
+	key := filenameCollisionKey(pending.typeDir, pending.baseName, pending.ext)
+
+	filenameIndexes[key]++
+
+	filename := formatDownloadFilename(
+		pending.baseName,
+		pending.ext,
+		filenameCounts[key],
+		filenameIndexes[key],
+	)
+
+	// If skipping existing files, first check the canonical filename.
+	// This prevents existing files from being downloaded again as _01, _02, etc.
+	if options.SkipExistingFiles {
+		canonicalPath := filepath.Join(pending.typeDir, formatDownloadFilename(pending.baseName, pending.ext, 1, 1))
+		if exists, err := fileExists(canonicalPath); err == nil && exists {
+			pending.task.outputPath = canonicalPath
+			tasks = append(tasks, pending.task)
+			continue
+		}
 	}
+
+	pending.task.outputPath = filepath.Join(pending.typeDir, filename)
+	tasks = append(tasks, pending.task)
+}
 
 	var downloadedCount int64
 	var skippedCount int64

--- a/frontend/src/components/DatabaseView.tsx
+++ b/frontend/src/components/DatabaseView.tsx
@@ -13,11 +13,16 @@ import { Spinner } from "@/components/ui/spinner";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, } from "@/components/ui/dropdown-menu";
 import { Trash2, FileInput, FileOutput, Pencil, Tag, Shuffle, X, XCircle, Download, StopCircle, Globe, Lock, Bookmark, Heart, Image, Images, Video, Film, FileText, Filter, AlertCircle, MoreVertical, FileBraces, CloudBackup, Search, LayoutGrid, Grid3X3, List, ArrowUpDown, ArrowUp, FolderOpen, Users, MessageSquare } from "lucide-react";
 import { toastWithSound as toast } from "@/lib/toast-with-sound";
-import { getSettings, renderFolderTemplate } from "@/lib/settings";
-import { beginDownload, finishDownload, useDownloadState } from "@/lib/download-state";
+import { getSettings } from "@/lib/settings";
 import { openExternal } from "@/lib/utils";
 import { GetAllAccountsFromDB, GetAccountFromDB, DeleteAccountFromDB, SaveAccountToDB, ExportAccountJSON, ExportAccountsTXT, UpdateAccountGroup, GetAllGroups, DownloadMediaWithMetadata, StopDownload, CheckFoldersExist, OpenFolder, GetFolderPath, } from "../../wailsjs/go/main/App";
+import { EventsOn } from "../../wailsjs/runtime/runtime";
 import { main } from "../../wailsjs/go/models";
+interface DownloadProgress {
+    current: number;
+    total: number;
+    percent: number;
+}
 function formatNumberWithComma(num: number): string {
     return num.toLocaleString();
 }
@@ -88,31 +93,23 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
     const [editGroupName, setEditGroupName] = useState("");
     const [editGroupColor, setEditGroupColor] = useState("");
     const [clearAllDialogOpen, setClearAllDialogOpen] = useState(false);
+    const [isDownloading, setIsDownloading] = useState(false);
+    const [downloadingAccountId, setDownloadingAccountId] = useState<number | null>(null);
+    const [downloadProgress, setDownloadProgress] = useState<DownloadProgress | null>(null);
     const [isBulkDownloading, setIsBulkDownloading] = useState(false);
     const [bulkDownloadCurrent, setBulkDownloadCurrent] = useState(0);
     const [bulkDownloadTotal, setBulkDownloadTotal] = useState(0);
     const stopBulkDownloadRef = useRef(false);
     const loadMoreRef = useRef<HTMLDivElement>(null);
     const [folderExistence, setFolderExistence] = useState<Map<number, boolean>>(new Map());
-    const downloadState = useDownloadState();
-    const anyDownloadActive = downloadState.active;
-    const isDownloading = downloadState.active && (downloadState.scope === "database" || downloadState.scope === "database-bulk");
-    const downloadingAccountId = isDownloading ? downloadState.accountId : null;
-    const downloadProgress = isDownloading ? downloadState.progress : null;
-    const getFolderNameForAccount = (username: string, accountName?: string) => {
+    const getFolderNameForAccount = (username: string) => {
         if (username === "bookmarks") {
             return "My Bookmarks";
         }
         if (username === "likes") {
             return "My Likes";
         }
-        const now = new Date();
-        const date = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, "0")}${String(now.getDate()).padStart(2, "0")}`;
-        return renderFolderTemplate(getSettings().folderTemplate, {
-            username,
-            accountName: accountName || username,
-            date,
-        }) || username;
+        return username;
     };
     const loadAccounts = useCallback(async () => {
         setLoading(true);
@@ -149,6 +146,14 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
         handleScroll();
         scrollElement.addEventListener("scroll", handleScroll);
         return () => scrollElement.removeEventListener("scroll", handleScroll);
+    }, []);
+    useEffect(() => {
+        const unsubscribe = EventsOn("download-progress", (progress: DownloadProgress) => {
+            setDownloadProgress(progress);
+        });
+        return () => {
+            unsubscribe();
+        };
     }, []);
     const scrollToTop = () => {
         getContentScrollElement()?.scrollTo({ top: 0, behavior: "smooth" });
@@ -221,7 +226,7 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
     }, [accountViewMode, filterGroup, filterMediaType, privateAccounts, publicAccounts, deferredSearchQuery, sortOrder]);
     const visibleAccounts = useMemo(() => filteredAccounts.slice(0, visibleCount), [filteredAccounts, visibleCount]);
     const visibleAccountsKey = visibleAccounts
-        .map((account) => `${account.id}:${account.username}:${account.name}`)
+        .map((account) => `${account.id}:${account.username}`)
         .join("|");
     useEffect(() => {
         const basePath = currentDownloadPath;
@@ -235,7 +240,7 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
         let active = true;
         const loadVisibleFolderExistence = async () => {
             try {
-                const folderNames = visibleAccounts.map((account) => getFolderNameForAccount(account.username, account.name));
+                const folderNames = visibleAccounts.map((account) => getFolderNameForAccount(account.username));
                 const results = await CheckFoldersExist(basePath, folderNames);
                 if (!active) {
                     return;
@@ -243,7 +248,7 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
                 setFolderExistence((prev) => {
                     const next = new Map(prev);
                     for (const account of visibleAccounts) {
-                        next.set(account.id, results[getFolderNameForAccount(account.username, account.name)] ?? false);
+                        next.set(account.id, results[getFolderNameForAccount(account.username)] ?? false);
                     }
                     return next;
                 });
@@ -312,17 +317,34 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
         }
     };
     const handleOpenFolder = async (account: AccountListItem) => {
-        const settings = getSettings();
-        const folderName = getFolderNameForAccount(account.username, account.name);
-        const folderPath = await GetFolderPath(settings.downloadPath, folderName);
-        try {
-            await OpenFolder(folderPath);
-        }
-        catch (error) {
-            console.error(`Failed to open folder for @${account.username}:`, error);
-            toast.error("Failed to open folder");
-        }
-    };
+    const settings = getSettings();
+    const basePath = settings.downloadPath || "";
+
+    if (!basePath) {
+        toast.error("Download folder is not set");
+        return;
+    }
+
+    let username = account.username || account.name || "";
+
+    try {
+        const responseJSON = await GetAccountFromDB(account.id);
+        const data = JSON.parse(responseJSON);
+        username = data.account_info?.name || username;
+    } catch {
+        // fall back to saved row data
+    }
+
+    const folderName = getFolderNameForAccount(username);
+
+    try {
+        const folderPath = await GetFolderPath(basePath, folderName);
+        await OpenFolder(folderPath);
+    } catch (error) {
+        console.error(`Failed to open folder for @${username}:`, error);
+        toast.error("Failed to open folder");
+    }
+};
     const handleDownload = async (id: number, username: string) => {
         try {
             const responseJSON = await GetAccountFromDB(id);
@@ -345,7 +367,9 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
                 outputDir = `${settings.downloadPath}${separator}My Likes`;
             }
             const actualUsername = data.account_info?.name || username;
-            beginDownload({ current: 0, total: timeline.length, percent: 0 }, { scope: "database", accountId: id });
+            setIsDownloading(true);
+            setDownloadingAccountId(id);
+            setDownloadProgress({ current: 0, total: timeline.length, percent: 0 });
             const request = new main.DownloadMediaWithMetadataRequest({
                 items: timeline.map((item: {
                     url: string;
@@ -354,7 +378,6 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
                     type: string;
                     original_filename?: string;
                     author_username?: string;
-                    author_name?: string;
                 }) => new main.MediaItemRequest({
                     url: item.url,
                     date: item.date,
@@ -362,7 +385,6 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
                     type: item.type,
                     original_filename: item.original_filename || "",
                     author_username: item.author_username || "",
-                    account_name: item.author_name || data.account_info?.nick || actualUsername,
                 })),
                 output_dir: outputDir,
                 username: actualUsername,
@@ -373,9 +395,6 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
                 proxy: settings.proxy || "",
                 filename_template: settings.filenameTemplate || "",
                 folder_template: settings.folderTemplate || "",
-                auto_convert_gifs: settings.autoConvertGifs,
-                gif_quality: settings.gifQuality || "fast",
-                gif_resolution: settings.gifResolution || "original",
             });
             const response = await DownloadMediaWithMetadata(request);
             if (response.cancelled) {
@@ -412,14 +431,15 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
             toast.error(`Download failed: ${errorMsg}`);
         }
         finally {
-            finishDownload();
+            setIsDownloading(false);
+            setDownloadingAccountId(null);
+            setDownloadProgress(null);
         }
     };
     const handleStopDownload = async () => {
         try {
             const stopped = await StopDownload();
             if (stopped) {
-                finishDownload();
                 toast.info("Download stopped");
             }
         }
@@ -451,7 +471,7 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
             if (!account)
                 continue;
             setBulkDownloadCurrent(i + 1);
-            beginDownload({ current: 0, total: 0, percent: 0 }, { scope: "database-bulk", accountId: id });
+            setDownloadingAccountId(id);
             try {
                 const responseJSON = await GetAccountFromDB(id);
                 const data = JSON.parse(responseJSON);
@@ -462,7 +482,7 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
                     toast.info("Bulk download stopped");
                     break;
                 }
-                beginDownload({ current: 0, total: timeline.length, percent: 0 }, { scope: "database-bulk", accountId: id });
+                setDownloadProgress({ current: 0, total: timeline.length, percent: 0 });
                 const isBookmarks = data.account_info?.nick === "My Bookmarks" || account.username === "bookmarks";
                 const isLikes = data.account_info?.nick === "My Likes" || account.username === "likes";
                 let outputDir = settings.downloadPath;
@@ -482,7 +502,6 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
                         tweet_id: string;
                         type: string;
                         author_username?: string;
-                        author_name?: string;
                         original_filename?: string;
                     }) => new main.MediaItemRequest({
                         url: item.url,
@@ -490,7 +509,6 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
                         tweet_id: item.tweet_id,
                         type: item.type,
                         author_username: item.author_username || "",
-                        account_name: item.author_name || data.account_info?.nick || actualUsername,
                         original_filename: item.original_filename || "",
                     })),
                     output_dir: outputDir,
@@ -502,9 +520,6 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
                     proxy: settings.proxy || "",
                     filename_template: settings.filenameTemplate || "",
                     folder_template: settings.folderTemplate || "",
-                    auto_convert_gifs: settings.autoConvertGifs,
-                    gif_quality: settings.gifQuality || "fast",
-                    gif_resolution: settings.gifResolution || "original",
                 });
                 const response = await DownloadMediaWithMetadata(request);
                 if (response.cancelled) {
@@ -523,7 +538,8 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
             }
         }
         setIsBulkDownloading(false);
-        finishDownload();
+        setDownloadingAccountId(null);
+        setDownloadProgress(null);
         setBulkDownloadCurrent(0);
         setBulkDownloadTotal(0);
         if ((totalDownloaded > 0 || totalSkipped > 0) && !stopBulkDownloadRef.current) {
@@ -820,7 +836,7 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
               <TooltipContent>Stop Bulk Download</TooltipContent>
             </Tooltip>) : (<Tooltip>
               <TooltipTrigger asChild>
-                <Button variant="default" size="icon" onClick={handleBulkDownload} disabled={selectedIds.size === 0 || anyDownloadActive}>
+                <Button variant="default" size="icon" onClick={handleBulkDownload} disabled={selectedIds.size === 0 || isDownloading}>
                   <Download className="h-4 w-4"/>
                 </Button>
               </TooltipTrigger>
@@ -1048,10 +1064,10 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
                         {formatNumberWithComma(account.total_media)} media
                       </div>
                     </div>
-                    <div className="flex gap-1">
+                    <div className="flex gap-1" onClick={(e) => e.stopPropagation()}>
                       {downloadingAccountId === account.id ? (<Button variant="outline" size="icon" className="h-8 w-8" onClick={handleStopDownload}>
                           <StopCircle className="h-4 w-4 text-destructive"/>
-                        </Button>) : (<Button variant="default" size="icon" className="h-8 w-8" onClick={() => handleDownload(account.id, account.username)} disabled={anyDownloadActive}>
+                        </Button>) : (<Button variant="default" size="icon" className="h-8 w-8" onClick={() => handleDownload(account.id, account.username)} disabled={isDownloading}>
                           <Download className="h-4 w-4"/>
                         </Button>)}
                       <Button variant="outline" size="icon" className="h-8 w-8" onClick={() => handleOpenFolder(account)} disabled={!folderExistence.get(account.id)}>
@@ -1064,7 +1080,12 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
-                          {!isPrivateAccount(account.username) && (<DropdownMenuItem onClick={() => handleEditGroup(account)}>
+                          {!isPrivateAccount(account.username) && (<DropdownMenuItem
+                              onSelect={(event) => {
+                                  event.preventDefault();
+                                  handleEditGroup(account);
+                              }}
+                            >
                               <Pencil className="h-4 w-4 mr-2"/>
                               Edit Group
                             </DropdownMenuItem>)}
@@ -1142,10 +1163,10 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
                         {formatNumberWithComma(account.total_media)} media
                       </div>
                     </div>
-                    <div className="flex gap-1">
+                    <div className="flex gap-1" onClick={(e) => e.stopPropagation()}>
                       {downloadingAccountId === account.id ? (<Button variant="outline" size="icon" className="h-7 w-7" onClick={handleStopDownload}>
                           <StopCircle className="h-3 w-3 text-destructive"/>
-                        </Button>) : (<Button variant="default" size="icon" className="h-7 w-7" onClick={() => handleDownload(account.id, account.username)} disabled={anyDownloadActive}>
+                        </Button>) : (<Button variant="default" size="icon" className="h-7 w-7" onClick={() => handleDownload(account.id, account.username)} disabled={isDownloading}>
                           <Download className="h-3 w-3"/>
                         </Button>)}
                       <Button variant="outline" size="icon" className="h-7 w-7" onClick={() => handleOpenFolder(account)} disabled={!folderExistence.get(account.id)}>
@@ -1158,7 +1179,12 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
-                          {!isPrivateAccount(account.username) && (<DropdownMenuItem onClick={() => handleEditGroup(account)}>
+                          {!isPrivateAccount(account.username) && (<DropdownMenuItem
+                              onSelect={(event) => {
+                                  event.preventDefault();
+                                  handleEditGroup(account);
+                              }}
+                            >
                               <Pencil className="h-4 w-4 mr-2"/>
                               Edit Group
                             </DropdownMenuItem>)}
@@ -1253,7 +1279,7 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
                     {account.last_fetched} {getRelativeTime(account.last_fetched)}
                   </div>
                 </div>
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
                   {downloadingAccountId === account.id ? (<Tooltip>
                       <TooltipTrigger asChild>
                         <Button variant="outline" size="icon" onClick={handleStopDownload}>
@@ -1263,7 +1289,7 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
                       <TooltipContent>Stop Download</TooltipContent>
                     </Tooltip>) : (<Tooltip>
                       <TooltipTrigger asChild>
-                        <Button variant="default" size="icon" onClick={() => handleDownload(account.id, account.username)} disabled={anyDownloadActive}>
+                        <Button variant="default" size="icon" onClick={() => handleDownload(account.id, account.username)} disabled={isDownloading}>
                           {isDownloading && downloadingAccountId === account.id ? (<Spinner className="h-4 w-4"/>) : (<Download className="h-4 w-4"/>)}
                         </Button>
                       </TooltipTrigger>
@@ -1289,7 +1315,12 @@ export function DatabaseView({ onLoadAccount, onUpdateSelected }: DatabaseViewPr
                       <TooltipContent>More Options</TooltipContent>
                     </Tooltip>
                     <DropdownMenuContent align="end">
-                      {!isPrivateAccount(account.username) && (<DropdownMenuItem onClick={() => handleEditGroup(account)}>
+                      {!isPrivateAccount(account.username) && (<DropdownMenuItem
+                          onSelect={(event) => {
+                              event.preventDefault();
+                              handleEditGroup(account);
+                          }}
+                        >
                           <Pencil className="h-4 w-4 mr-2"/>
                           Edit Group
                         </DropdownMenuItem>)}


### PR DESCRIPTION
This PR fixes two issues introduced in v4.8.

Edit Group

Clicking Edit Group from the account menu triggered the parent account-card click, navigating to the account page instead of opening the group dialog. This change prevents the event from bubbling so the dialog opens correctly.

Skip Existing Posts

When Skip Existing Posts was enabled, existing files were sometimes downloaded again with _01 appended to the filename. The duplicate filename was being generated before checking whether the original file already existed. This change checks the canonical filename first so previously downloaded posts are skipped as intended.